### PR TITLE
Treat ... as a separate token

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -469,6 +469,16 @@ fn lex_internal(
         } else if c == b' ' || c == b'\t' || additional_whitespace.contains(&c) {
             // If the next character is non-newline whitespace, skip it.
             curr_offset += 1;
+        } else if c == b'.'
+            && input.get(curr_offset + 1).is_some_and(|c| *c == b'.')
+            && input.get(curr_offset + 2).is_some_and(|c| *c == b'.')
+        {
+            let start = curr_offset;
+            curr_offset += 3;
+            output.push(Token::new(
+                TokenContents::Item,
+                Span::new(span_offset + start, span_offset + curr_offset),
+            ));
         } else {
             // Otherwise, try to consume an unclassified token.
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3707,7 +3707,10 @@ pub fn parse_list_expression(
                                 working_set,
                                 &command.parts,
                                 &mut spans_idx,
-                                &SyntaxShape::List(Box::new(element_shape.clone())),
+                                &SyntaxShape::OneOf(vec![
+                                    SyntaxShape::List(Box::new(element_shape.clone())),
+                                    SyntaxShape::String,
+                                ]),
                             );
                             let elem_ty = match &spread_arg.ty {
                                 Type::List(elem_ty) => *elem_ty.clone(),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3081,7 +3081,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
         AfterCommaArgMode,
         TypeMode,
         DefaultValueMode,
-        RestParamMode
+        RestParamMode,
     }
 
     #[derive(Debug)]

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -765,6 +765,11 @@ fn implied_collect_has_compatible_type() -> TestResult {
 }
 
 #[test]
-fn spread_in_list() -> TestResult {
-    run_test(r#"[1 2 ...[3 4] 5] | str join ' '"#, "1 2 3 4 5")
+fn spread_list_in_list() -> TestResult {
+    run_test(r#"[1 2 ...[3 4] 5] | str join " ""#, "1 2 3 4 5")
+}
+
+#[test]
+fn spread_str_in_list() -> TestResult {
+    run_test(r#"[..."foo"] | str join " ""#, "f o o")
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -763,3 +763,8 @@ fn properly_typecheck_rest_param() -> TestResult {
 fn implied_collect_has_compatible_type() -> TestResult {
     run_test(r#"let idx = 3 | $in; $idx < 1"#, "false")
 }
+
+#[test]
+fn spread_in_list() -> TestResult {
+    run_test(r#"[1 2 ...[3 4] 5] | str join ' '"#, "1 2 3 4 5")
+}


### PR DESCRIPTION
Just for experimenting with having the lexer treat `...` as a separate token, to make `parse_list_expression`'s life easier